### PR TITLE
Miscelaneous fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `IdToken::getClaim` method to return default value if claim is not found
+
 ## [0.2.4] - 2026-02-19
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix `IdToken::getClaim` method to return default value if claim is not found
 - Fix `nonce` handling in `AuthCodeGrant` to only set if present in request
+- Fix error messages in `EndSessionController` for ID token verification
 
 ## [0.2.4] - 2026-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `IdToken::getClaim` method to return default value if claim is not found
+- Fix `nonce` handling in `AuthCodeGrant` to only set if present in request
 
 ## [0.2.4] - 2026-02-19
 

--- a/src/Controller/EndSessionController.php
+++ b/src/Controller/EndSessionController.php
@@ -227,11 +227,11 @@ final readonly class EndSessionController
             $constraints = $jwtConfiguration->validationConstraints();
             $jwtConfiguration->validator()->assert($token, ...$constraints);
         } catch (RequiredConstraintsViolated $exception) {
-            throw new BadRequestHttpException('Access token could not be verified', $exception);
+            throw new BadRequestHttpException('ID token could not be verified', $exception);
         }
 
         if (!$token instanceof UnencryptedToken) {
-            throw new BadRequestHttpException('Access token is not an instance of UnencryptedToken');
+            throw new BadRequestHttpException('ID token is not an instance of UnencryptedToken');
         }
     }
 

--- a/src/Model/IdToken.php
+++ b/src/Model/IdToken.php
@@ -74,7 +74,7 @@ final readonly class IdToken implements IdTokenInterface
 
     public function getClaim(string $name, mixed $default = null): mixed
     {
-        return $this->token->claims()->get($name);
+        return $this->token->claims()->get($name, $default);
     }
 
     public function __toString(): string

--- a/src/OAuth2/AuthCodeGrant.php
+++ b/src/OAuth2/AuthCodeGrant.php
@@ -55,7 +55,9 @@ final class AuthCodeGrant extends LeagueAuthCodeGrant
         }
 
         $payload = json_decode($this->decrypt($queryParams['code']), true, \JSON_THROW_ON_ERROR);
-        $payload['nonce'] = $request->query->getString('nonce');
+        if ($request->query->has('nonce')) {
+            $payload['nonce'] = $request->query->getString('nonce');
+        }
         if ($request->hasSession()) {
             $payload['sid'] = $this->getOrGenerateSid($request->getSession());
         }


### PR DESCRIPTION
- Fix `IdToken::getClaim` method to return default value if claim is not found
- Fix `nonce` handling in `AuthCodeGrant` to only set if present in request
- Fix error messages in `EndSessionController` for ID token verification