### PR TITLE
Require `offline_access` scope for refresh token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add a new `$clientClass` parameter to `Driver` to support custom clients
 - Add `kid` value in JWKS
+- Add autoregistration of `offline_access` scope
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a new `$clientClass` parameter to `Driver` to support custom clients
 - Add `kid` value in JWKS
 - Add autoregistration of `offline_access` scope
+- Add `$refreshTokenRequireOfflineAccess` to `AuthCodeGrant`
+- Add `refresh_token_require_offline_access_scope` configuration parameter with a default value of `false`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add autoregistration of `offline_access` scope
 - Add `$refreshTokenRequireOfflineAccess` to `AuthCodeGrant`
 - Add `refresh_token_require_offline_access_scope` configuration parameter with a default value of `false`
+- Add `RefreshTokenOfflineAccessExpiryListener` to immediately expire refresh tokens
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ AjgarlagOpenIDConnectProviderBundle is a Symfony bundle that integrates an OpenI
 
     ```yaml
     ajgarlag_openid_connect_provider:
+        authorization_server:
+            refresh_token_require_offline_access_scope: false
         discovery:
             authorization_endpoint_route: 'oauth2_authorize'
             token_endpoint_route: 'oauth2_token'

--- a/config/services.php
+++ b/config/services.php
@@ -10,6 +10,7 @@ use Ajgarlag\Bundle\OpenIDConnectProviderBundle\Controller\DiscoveryController;
 use Ajgarlag\Bundle\OpenIDConnectProviderBundle\Controller\EndSessionController;
 use Ajgarlag\Bundle\OpenIDConnectProviderBundle\Controller\JwksController;
 use Ajgarlag\Bundle\OpenIDConnectProviderBundle\EventListener\PostLogoutRedirectListener;
+use Ajgarlag\Bundle\OpenIDConnectProviderBundle\EventListener\RefreshTokenOfflineAccessExpiryListener;
 use Ajgarlag\Bundle\OpenIDConnectProviderBundle\Logout\CachePostLogoutRedirectUriStorage;
 use Ajgarlag\Bundle\OpenIDConnectProviderBundle\Logout\PostLogoutRedirectUriStorageInterface;
 use Ajgarlag\Bundle\OpenIDConnectProviderBundle\Manager\RelyingPartyManagerInterface;
@@ -56,6 +57,14 @@ return static function (ContainerConfigurator $container): void {
             ])
             ->tag('kernel.event_subscriber')
         ->alias(PostLogoutRedirectListener::class, 'ajgarlag.openid_connect_provider.listener.post_logout_redirect')
+
+        ->set('ajgarlag.openid_connect_provider.listener.refresh_token_offline_access_expiry', RefreshTokenOfflineAccessExpiryListener::class)
+            ->args([
+                '%ajgarlag_openid_connect_provider.authorization_server.refresh_token_require_offline_access_scope%',
+                service('clock'),
+            ])
+            ->tag('kernel.event_subscriber')
+        ->alias(RefreshTokenOfflineAccessExpiryListener::class, 'ajgarlag.openid_connect_provider.listener.refresh_token_offline_access_expiry')
 
         ->set('ajgarlag.openid_connect_provider.command.show_relying_party', ShowRelyingPartyCommand::class)
             ->args([

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,9 +14,9 @@
     </php>
 
     <testsuites>
-        <!-- <testsuite name="unit">
+        <testsuite name="unit">
             <directory>./tests/Unit</directory>
-        </testsuite> -->
+        </testsuite>
         <testsuite name="acceptance">
             <directory>./tests/Acceptance</directory>
         </testsuite>

--- a/src/DependencyInjection/AjgarlagOpenIDConnectProviderExtension.php
+++ b/src/DependencyInjection/AjgarlagOpenIDConnectProviderExtension.php
@@ -25,6 +25,7 @@ final class AjgarlagOpenIDConnectProviderExtension extends Extension
 
         $this->configureDiscovery($container, $config['discovery']);
         $this->configureEndSession($container, $config['end_session']);
+        $this->configureAuthorizationServer($container, $config['authorization_server']);
     }
 
     /**
@@ -48,5 +49,16 @@ final class AjgarlagOpenIDConnectProviderExtension extends Extension
         $container->getDefinition('ajgarlag.openid_connect_provider.controller.end_session')
             ->replaceArgument(8, $config['cancel_logout_default_path'])
         ;
+    }
+
+    /**
+     * @param mixed[] $config
+     */
+    private function configureAuthorizationServer(ContainerBuilder $container, array $config): void
+    {
+        $container->setParameter(
+            'ajgarlag_openid_connect_provider.authorization_server.refresh_token_require_offline_access_scope',
+            $config['refresh_token_require_offline_access_scope']
+        );
     }
 }

--- a/src/DependencyInjection/Compiler/AuthCodeGrantCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AuthCodeGrantCompilerPass.php
@@ -21,6 +21,7 @@ final class AuthCodeGrantCompilerPass implements CompilerPassInterface
             ->setArgument(3, new Reference(RequestStack::class))
             ->setArgument(4, new Reference(ResponseFactoryInterface::class))
             ->setArgument(5, new Reference(UriFactoryInterface::class))
+            ->setArgument(6, '%ajgarlag_openid_connect_provider.authorization_server.refresh_token_require_offline_access_scope%')
         ;
     }
 }

--- a/src/DependencyInjection/Compiler/OpenIdScopeCompilerPass.php
+++ b/src/DependencyInjection/Compiler/OpenIdScopeCompilerPass.php
@@ -19,5 +19,8 @@ final class OpenIdScopeCompilerPass implements CompilerPassInterface
         $scopeManagerDefinition->addMethodCall('save', [
             new Definition(Scope::class, ['openid']),
         ]);
+        $scopeManagerDefinition->addMethodCall('save', [
+            new Definition(Scope::class, ['offline_access']),
+        ]);
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -79,7 +79,7 @@ final class Configuration implements ConfigurationInterface
             ->addDefaultsIfNotSet()
             ->children()
                 ->booleanNode('refresh_token_require_offline_access_scope')
-                    ->info('Whether refresh tokens require the offline_access scope to be requested')
+                    ->info('Whether refresh tokens require the offline_access scope to be requested. If true, refresh tokens will not be issued or will be issued with immediate expiry if offline_access is not requested.')
                     ->defaultFalse()
                 ->end()
             ->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,6 +17,7 @@ final class Configuration implements ConfigurationInterface
 
         $rootNode->append($this->createDiscoveryNode());
         $rootNode->append($this->createEndSessionNode());
+        $rootNode->append($this->createAuthorizationServerNode());
 
         return $treeBuilder;
     }
@@ -62,6 +63,24 @@ final class Configuration implements ConfigurationInterface
                 ->scalarNode('cancel_logout_default_path')
                     ->info('URL or route names to redirect user on session ending if no post logout redirect URI is given.')
                     ->defaultValue('/')
+                ->end()
+            ->end()
+        ;
+
+        return $node;
+    }
+
+    private function createAuthorizationServerNode(): NodeDefinition
+    {
+        $treeBuilder = new TreeBuilder('authorization_server');
+        $node = $treeBuilder->getRootNode();
+
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->booleanNode('refresh_token_require_offline_access_scope')
+                    ->info('Whether refresh tokens require the offline_access scope to be requested')
+                    ->defaultFalse()
                 ->end()
             ->end()
         ;

--- a/src/EventListener/RefreshTokenOfflineAccessExpiryListener.php
+++ b/src/EventListener/RefreshTokenOfflineAccessExpiryListener.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ajgarlag\Bundle\OpenIDConnectProviderBundle\EventListener;
+
+use League\OAuth2\Server\RequestRefreshTokenEvent;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final readonly class RefreshTokenOfflineAccessExpiryListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private bool $requireOfflineAccessScope = false,
+        private ?ClockInterface $clock = null,
+    ) {
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'refresh_token.issued' => 'onRefreshTokenIssued',
+        ];
+    }
+
+    public function onRefreshTokenIssued(RequestRefreshTokenEvent $event): void
+    {
+        if (!$this->requireOfflineAccessScope) {
+            return;
+        }
+
+        $refreshToken = $event->getRefreshToken();
+
+        foreach ($refreshToken->getAccessToken()->getScopes() as $scope) {
+            if ('offline_access' === $scope->getIdentifier()) {
+                return;
+            }
+        }
+
+        $refreshToken->setExpiryDateTime($this->clock?->now() ?? new \DateTimeImmutable());
+    }
+}

--- a/src/OAuth2/AuthCodeGrant.php
+++ b/src/OAuth2/AuthCodeGrant.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Ajgarlag\Bundle\OpenIDConnectProviderBundle\OAuth2;
 
 use Ajgarlag\Bundle\OpenIDConnectProviderBundle\OpenIDConnect\SessionSidTrait;
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
 use League\OAuth2\Server\Grant\AuthCodeGrant as LeagueAuthCodeGrant;
 use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
@@ -26,8 +28,21 @@ final class AuthCodeGrant extends LeagueAuthCodeGrant
         private readonly RequestStack $requestStack,
         private readonly ResponseFactoryInterface $responseFactory,
         private readonly UriFactoryInterface $uriFactory,
+        private readonly bool $refreshTokenRequireOfflineAccess = true,
     ) {
         parent::__construct($authCodeRepository, $refreshTokenRepository, $authCodeTTL);
+    }
+
+    protected function issueRefreshToken(AccessTokenEntityInterface $accessToken): ?RefreshTokenEntityInterface
+    {
+        if (
+            $this->refreshTokenRequireOfflineAccess
+            && !$this->hasScope($accessToken, 'offline_access')
+        ) {
+            return null;
+        }
+
+        return parent::issueRefreshToken($accessToken);
     }
 
     public function completeAuthorizationRequest(AuthorizationRequestInterface $authorizationRequest): ResponseTypeInterface
@@ -65,5 +80,16 @@ final class AuthCodeGrant extends LeagueAuthCodeGrant
         $response->setRedirectUri($psr7Uri->withQuery(http_build_query($queryParams))->__toString());
 
         return $response;
+    }
+
+    private function hasScope(AccessTokenEntityInterface $accessToken, string $scopeIdentifier): bool
+    {
+        foreach ($accessToken->getScopes() as $scope) {
+            if ($scopeIdentifier === $scope->getIdentifier()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Acceptance/TokenEndpointTest.php
+++ b/tests/Acceptance/TokenEndpointTest.php
@@ -44,6 +44,7 @@ final class TokenEndpointTest extends AbstractAcceptanceTestCase
         $this->assertSame('Bearer', $jsonResponse['token_type']);
         $this->assertEqualsWithDelta(3600, $jsonResponse['expires_in'], 1.0);
         $this->assertNotEmpty($jsonResponse['access_token']);
+        $this->assertNotEmpty($jsonResponse['refresh_token']);
 
         $this->assertNotEmpty($jsonResponse['id_token']);
         $token = (new Parser(new JoseEncoder()))->parse($jsonResponse['id_token']);
@@ -54,6 +55,42 @@ final class TokenEndpointTest extends AbstractAcceptanceTestCase
         $this->assertNotEmpty($token->claims()->get('aud'));
         $this->assertNotEmpty($token->claims()->get('exp'));
         $this->assertNotEmpty($token->claims()->get('iat'));
+    }
+
+    /**
+     * @group time-sensitive
+     */
+    public function testSuccessfulIdTokenRequestDoesNotIncludeRefreshTokenWhenOfflineAccessIsRequired(): void
+    {
+        $client = self::createClient(['environment' => 'require_offline_access']);
+
+        $authCodeOpenID = $client
+            ->getContainer()
+            ->get(AuthorizationCodeManagerInterface::class)
+            ->find(FixtureFactory::FIXTURE_AUTH_CODE_OPENID_CONNECT)
+        ;
+
+        $client->request('POST', '/token', [
+            'client_id' => 'client_openid_connect',
+            'client_secret' => 'secret_openid_connect',
+            'grant_type' => 'authorization_code',
+            'redirect_uri' => 'https://example.org/openid_connect/redirect-uri',
+            'code' => TestHelper::generateEncryptedAuthCodePayload($authCodeOpenID, 'n0nc3'),
+        ]);
+
+        $response = $client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('application/json; charset=UTF-8', $response->headers->get('Content-Type'));
+
+        $jsonResponse = json_decode($response->getContent(), true);
+
+        $this->assertSame('Bearer', $jsonResponse['token_type']);
+        $this->assertEqualsWithDelta(3600, $jsonResponse['expires_in'], 1.0);
+        $this->assertNotEmpty($jsonResponse['access_token']);
+        $this->assertArrayNotHasKey('refresh_token', $jsonResponse);
+
+        $this->assertNotEmpty($jsonResponse['id_token']);
     }
 
     public function testClientCredentialsFlowOmitsIdToken(): void

--- a/tests/Fixtures/config/packages/require_offline_access/ajgarlag_openid_connect_provider.php
+++ b/tests/Fixtures/config/packages/require_offline_access/ajgarlag_openid_connect_provider.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container): void {
+    $container->extension('ajgarlag_openid_connect_provider', [
+        'authorization_server' => [
+            'refresh_token_require_offline_access_scope' => true,
+        ],
+    ]);
+};

--- a/tests/Unit/EventListener/RefreshTokenOfflineAccessExpiryListenerTest.php
+++ b/tests/Unit/EventListener/RefreshTokenOfflineAccessExpiryListenerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ajgarlag\Bundle\OpenIDConnectProviderBundle\Tests\Unit\EventListener;
+
+use Ajgarlag\Bundle\OpenIDConnectProviderBundle\EventListener\RefreshTokenOfflineAccessExpiryListener;
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use League\OAuth2\Server\RequestRefreshTokenEvent;
+use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class RefreshTokenOfflineAccessExpiryListenerTest extends TestCase
+{
+    public function testListenerExpiresRefreshTokenImmediatelyWhenOfflineAccessNotRequested(): void
+    {
+        $now = new \DateTimeImmutable();
+        $clock = $this->createMock(ClockInterface::class);
+        $clock->method('now')->willReturn($now);
+
+        $listener = new RefreshTokenOfflineAccessExpiryListener(true, $clock);
+
+        // Create access token with openid scope but no offline_access
+        $openidScope = $this->createMock(ScopeEntityInterface::class);
+        $openidScope->method('getIdentifier')->willReturn('openid');
+
+        $accessToken = $this->createMock(AccessTokenEntityInterface::class);
+        $accessToken->method('getScopes')->willReturn([$openidScope]);
+
+        // Create refresh token with the access token
+        $refreshToken = $this->createMock(RefreshTokenEntityInterface::class);
+        $refreshToken->method('getAccessToken')->willReturn($accessToken);
+        $refreshToken->expects($this->once())
+            ->method('setExpiryDateTime')
+            ->with($now);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $event = new RequestRefreshTokenEvent('refresh_token.issued', $request, $refreshToken);
+        $listener->onRefreshTokenIssued($event);
+    }
+
+    public function testListenerDoesNotExpireRefreshTokenWhenOfflineAccessIsRequested(): void
+    {
+        $clock = $this->createMock(ClockInterface::class);
+        $clock->expects($this->never())->method('now');
+
+        $listener = new RefreshTokenOfflineAccessExpiryListener(true, $clock);
+
+        // Create access token with both openid and offline_access scopes
+        $openidScope = $this->createMock(ScopeEntityInterface::class);
+        $openidScope->method('getIdentifier')->willReturn('openid');
+
+        $offlineAccessScope = $this->createMock(ScopeEntityInterface::class);
+        $offlineAccessScope->method('getIdentifier')->willReturn('offline_access');
+
+        $accessToken = $this->createMock(AccessTokenEntityInterface::class);
+        $accessToken->method('getScopes')->willReturn([$openidScope, $offlineAccessScope]);
+
+        // Create refresh token
+        $refreshToken = $this->createMock(RefreshTokenEntityInterface::class);
+        $refreshToken->method('getAccessToken')->willReturn($accessToken);
+        $refreshToken->expects($this->never())->method('setExpiryDateTime');
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $event = new RequestRefreshTokenEvent('refresh_token.issued', $request, $refreshToken);
+        $listener->onRefreshTokenIssued($event);
+    }
+
+    public function testListenerDisabledDoesNotExpireRefreshToken(): void
+    {
+        $clock = $this->createMock(ClockInterface::class);
+        $clock->expects($this->never())->method('now');
+
+        $listener = new RefreshTokenOfflineAccessExpiryListener(false, $clock);
+
+        // Create access token without offline_access
+        $openidScope = $this->createMock(ScopeEntityInterface::class);
+        $openidScope->method('getIdentifier')->willReturn('openid');
+
+        $accessToken = $this->createMock(AccessTokenEntityInterface::class);
+        $accessToken->method('getScopes')->willReturn([$openidScope]);
+
+        // Create refresh token
+        $refreshToken = $this->createMock(RefreshTokenEntityInterface::class);
+        $refreshToken->method('getAccessToken')->willReturn($accessToken);
+        $refreshToken->expects($this->never())->method('setExpiryDateTime');
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $event = new RequestRefreshTokenEvent('refresh_token.issued', $request, $refreshToken);
+        $listener->onRefreshTokenIssued($event);
+    }
+
+    public function testListenerUsesCurrentTimeWhenClockNotProvided(): void
+    {
+        $listener = new RefreshTokenOfflineAccessExpiryListener(true, null);
+
+        // Create access token without offline_access
+        $openidScope = $this->createMock(ScopeEntityInterface::class);
+        $openidScope->method('getIdentifier')->willReturn('openid');
+
+        $accessToken = $this->createMock(AccessTokenEntityInterface::class);
+        $accessToken->method('getScopes')->willReturn([$openidScope]);
+
+        // Create refresh token
+        $refreshToken = $this->createMock(RefreshTokenEntityInterface::class);
+        $refreshToken->method('getAccessToken')->willReturn($accessToken);
+
+        $beforeCall = new \DateTimeImmutable();
+        $refreshToken->expects($this->once())
+            ->method('setExpiryDateTime')
+            ->with($this->callback(static fn ($dateTime): bool => $dateTime >= $beforeCall && $dateTime <= new \DateTimeImmutable()));
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $event = new RequestRefreshTokenEvent('refresh_token.issued', $request, $refreshToken);
+        $listener->onRefreshTokenIssued($event);
+    }
+}


### PR DESCRIPTION
Implement a requirement for the offline_access scope when issuing refresh tokens. If the scope is not present, the refresh token will not be issued, or will expire immediately. This change enhances security by ensuring that refresh tokens are only issued when the appropriate scope is requested.